### PR TITLE
fix(spec): signTypedData_v4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,25 @@
+# GitHub Nodejs CI
+name: nodejs
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['14.x']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build
+          npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eth-sig-util",
-  "version": "3.0.1",
+  "name": "transaction-sign-utils",
+  "version": "3.1.0",
   "description": "A few useful functions for signing ethereum data",
   "main": "dist/index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/MetaMask/eth-sig-util.git"
+    "url": "git+ssh://git@github.com/sambacha/eth-sig-util.git"
   },
   "keywords": [
     "ethereum",
@@ -25,14 +25,14 @@
   "author": "Dan Finlay",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/MetaMask/eth-sig-util/issues"
+    "url": "https://github.com/sambacha/eth-sig-util/issues"
   },
-  "homepage": "https://github.com/MetaMask/eth-sig-util#readme",
+  "homepage": "https://github.com/sambacha/eth-sig-util#readme",
   "dependencies": {
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^5.1.1",
     "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.0"
+    "tweetnacl-util": "^0.15.1"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,15 @@ const TypedDataUtils = {
 
         if (type.lastIndexOf(']') === type.length - 1) {
           const parsedType = type.slice(0, type.lastIndexOf('['));
+          
+          // @note Fix encoding of array in signTypedData_v4 #1 
+          // If it's a struct, we concatenate their encodedData and then take the keccak256
+          // as per "The array values are encoded as the keccak256 hash of the concatenated encodeData of their contents"
+          if (types[parsedType] !== undefined) {
+            const typeValuePairs = value.map((item) => this.encodeData(parsedType, item, types));
+            return ['bytes32', ethUtil.sha3(Buffer.concat(typeValuePairs))];
+          }
+          // Otherwise we use encodeField as it's not a struct
           const typeValuePairs = value.map((item) => encodeField(name, parsedType, item));
           return [
             'bytes32',

--- a/test/index.ts
+++ b/test/index.ts
@@ -803,7 +803,7 @@ test('signedTypeData_v4', (t) => {
     `0x${[
       '4bd8a9a2b93427bb184aca81e24beb30ffa3c747e2a33d4225ec08bf12e2e753',
       '9b4846dd48b866f0ac54d61b9b21a9e746f921cefa4ee94c4c0a1c49c774f67f',
-      'ca322beec85be24e374d18d582a6f2997f75c54e7993ab5bc07404ce176ca7cd',
+      'efa62530c7ae3a290f8a13a5fc20450bdb3a6af19d9d9d2542b5a94e631a9168',
       'b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8',
     ].join('')}`
   );
@@ -815,7 +815,7 @@ test('signedTypeData_v4', (t) => {
         typedData.types
       )
     ),
-    '0xeb4221181ff3f1a83ea7313993ca9218496e424604ba9492bb4052c03d5c3df8'
+    '0x99b97a26b830a26d5ca27ced87ba4d73c6276a2b8315656882a771d6f98b01f3'
   );
   t.equal(
     ethUtil.bufferToHex(
@@ -825,7 +825,7 @@ test('signedTypeData_v4', (t) => {
   );
   t.equal(
     ethUtil.bufferToHex(utils.sign(typedData)),
-    '0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2'
+    '0x66c6a7d830704b2b1c4a4245129d468a84449b50a6237f6fad4a38a0ace770a1'
   );
 
   const privateKey = ethUtil.keccak('cow');
@@ -840,8 +840,7 @@ test('signedTypeData_v4', (t) => {
 
   t.equal(
     sig,
-    '0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b'
-  );
+'0xf632e305033e23de75545fcdd0a481d83d9d41954e12c07004327cddf4e3c762757652b04d11dd022e0018e6160723f322d0b4bd9b41c87db93755405f5548391b');
 });
 
 test('signedTypeData_v4', (t) => {
@@ -967,7 +966,7 @@ test('signedTypeData_v4', (t) => {
     `0x${[
       '4bd8a9a2b93427bb184aca81e24beb30ffa3c747e2a33d4225ec08bf12e2e753',
       '9b4846dd48b866f0ac54d61b9b21a9e746f921cefa4ee94c4c0a1c49c774f67f',
-      'ca322beec85be24e374d18d582a6f2997f75c54e7993ab5bc07404ce176ca7cd',
+      'efa62530c7ae3a290f8a13a5fc20450bdb3a6af19d9d9d2542b5a94e631a9168',
       'b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8',
     ].join('')}`
   );
@@ -979,7 +978,7 @@ test('signedTypeData_v4', (t) => {
         typedData.types
       )
     ),
-    '0xeb4221181ff3f1a83ea7313993ca9218496e424604ba9492bb4052c03d5c3df8'
+    '0x99b97a26b830a26d5ca27ced87ba4d73c6276a2b8315656882a771d6f98b01f3'
   );
   t.equal(
     ethUtil.bufferToHex(
@@ -989,7 +988,7 @@ test('signedTypeData_v4', (t) => {
   );
   t.equal(
     ethUtil.bufferToHex(utils.sign(typedData)),
-    '0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2'
+    '0x66c6a7d830704b2b1c4a4245129d468a84449b50a6237f6fad4a38a0ace770a1'
   );
 
   const privateKey = ethUtil.keccak('cow');
@@ -1004,8 +1003,7 @@ test('signedTypeData_v4', (t) => {
 
   t.equal(
     sig,
-    '0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b'
-  );
+'0xf632e305033e23de75545fcdd0a481d83d9d41954e12c07004327cddf4e3c762757652b04d11dd022e0018e6160723f322d0b4bd9b41c87db93755405f5548391b');
 });
 
 test('signedTypeData_v4 with recursive types', (t) => {


### PR DESCRIPTION
source: https://github.com/cammellos/eth-sig-util/commit/9778b62669dc4dde94224a71d0e1c3060a21a2a4
Fix encoding of array in signTypedData_v4

Currently, the behavior of signTypedData_v4 is not according to
eips.ethereum.org/EIPS/eip-712 when it comes to encoding arrays.

The eip states: "The array values are encoded as the keccak256 hash of the
concatenated encodeData of their contents".

The behavior instead was to encode array values as the keccak256 of the
concatenated keccak256 of the values.

This worked well for primary types, but not for struct, as encodeData
per spec is: "The encoding of a struct instance is
enc(value₁) ‖ enc(value₂) ‖ … ‖ enc(valueₙ) , i.e. the concatenation of the
encoded member values in the order that they appear in the type.
Each encoded member value is exactly 32-byte long.".

Instead, we were using basically `hashStruct` instead of `encodeData